### PR TITLE
tslint.json

### DIFF
--- a/Steckbrief/tslint.json
+++ b/Steckbrief/tslint.json
@@ -1,0 +1,62 @@
+{
+	"rules": {
+		"align": [true, "parameters", "arguments", "statements"],
+		"ban": false,
+		"class-name": true,
+		"comment-format": [false, "check-space", "check-lowercase"],
+		"curly": false,
+		"eofline": false,
+		"forin": false,
+		"indent": [true, 4],
+		"interface-name": false,
+		"jsdoc-format": false,
+		"label-position": true,
+		"label-undefined": true,
+		"max-line-length": [false, 140],
+		"member-ordering": [true, "static-before-instance", "variables-before-functions"],
+		"no-any": false,
+		"no-arg": true,
+		"no-bitwise": true,
+		"no-console": [false, "debug", "info", "time", "timeEnd", "trace"],
+		"no-construct": true,
+		"no-constructor-vars": true,
+		"no-debugger": true,
+		"no-duplicate-key": true,
+		"no-duplicate-variable": true,
+		"no-empty": true,
+		"no-eval": true,
+		"no-string-literal": false,
+		"no-switch-case-fall-through": false,
+		"trailing-comma": [true, {
+				"singleline": "never",
+				"multiline": "never"
+			}
+		],
+		"no-trailing-whitespace": false,
+		"no-unreachable": true,
+		"no-unused-expression": true,
+		"no-unused-variable": false,
+		"no-use-before-declare": true,
+		"no-var-requires": false,
+		"no-conditional-assignment": true,
+		"no-shadowed-variable": false,
+		"one-line": [true, "check-open-brace", "check-catch", "check-whitespace"],
+		"quotemark": [true, "double"],
+		"radix": false,
+		"semicolon": true,
+		"switch-default": false,
+		"triple-equals": [false, "allow-null-check"],
+		"typedef": [true, "call-signature", "parameter", "property-declaration", "variable-declaration", "member-variable-declaration"],
+		"typedef-whitespace": [true, {
+				"call-signature": "nospace",
+				"index-signature": "nospace",
+				"parameter": "nospace",
+				"property-declaration": "nospace",
+				"variable-declaration": "nospace"
+			}
+		],
+		"use-strict": [false, "check-module", "check-function"],
+		"variable-name": [true, "allow-leading-underscore"],
+		"whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
+	}
+}


### PR DESCRIPTION
{
	"rules": {
		"align": [true, "parameters", "arguments", "statements"],
		"ban": false,
		"class-name": true,
		"comment-format": [false, "check-space", "check-lowercase"],
		"curly": false,
		"eofline": false,
		"forin": false,
		"indent": [true, 4],
		"interface-name": false,
		"jsdoc-format": false,
		"label-position": true,
		"label-undefined": true,
		"max-line-length": [false, 140],
		"member-ordering": [true, "static-before-instance", "variables-before-functions"],
		"no-any": false,
		"no-arg": true,
		"no-bitwise": true,
		"no-console": [false, "debug", "info", "time", "timeEnd", "trace"],
		"no-construct": true,
		"no-constructor-vars": true,
		"no-debugger": true,
		"no-duplicate-key": true,
		"no-duplicate-variable": true,
		"no-empty": true,
		"no-eval": true,
		"no-string-literal": false,
		"no-switch-case-fall-through": false,
		"trailing-comma": [true, {
				"singleline": "never",
				"multiline": "never"
			}
		],
		"no-trailing-whitespace": false,
		"no-unreachable": true,
		"no-unused-expression": true,
		"no-unused-variable": false,
		"no-use-before-declare": true,
		"no-var-requires": false,
		"no-conditional-assignment": true,
		"no-shadowed-variable": false,
		"one-line": [true, "check-open-brace", "check-catch", "check-whitespace"],
		"quotemark": [true, "double"],
		"radix": false,
		"semicolon": true,
		"switch-default": false,
		"triple-equals": [false, "allow-null-check"],
		"typedef": [true, "call-signature", "parameter", "property-declaration", "variable-declaration", "member-variable-declaration"],
		"typedef-whitespace": [true, {
				"call-signature": "nospace",
				"index-signature": "nospace",
				"parameter": "nospace",
				"property-declaration": "nospace",
				"variable-declaration": "nospace"
			}
		],
		"use-strict": [false, "check-module", "check-function"],
		"variable-name": [true, "allow-leading-underscore"],
		"whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type"]
	}
}